### PR TITLE
Add `Cardinals` project to the list

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -46,6 +46,7 @@ Una lista curada de increíbles proyectos católicos, bibliotecas y software.
 * [![Go](https://img.shields.io/badge/language-Go-cyan)](#) [vulgata](https://github.com/borderstech/vulgata) - La Santa Biblia con los textos en inglés de Douay-Rheims y en latín de Clementina Vulgata
 * [![Python](https://img.shields.io/badge/language-Python-blue)](#) [catechism-ccc-json](https://github.com/nossbigg/catechism-ccc-json) - El Catecismo de la Iglesia Católica en JSON.
 * [![Python](https://img.shields.io/badge/language-Python-blue)](#) [pytholic](https://github.com/Medromenax/pytholic) - Paquete Python de temática católica
+* [![Python](https://img.shields.io/badge/language-Python-blue)](#) [cardinals](https://github.com/ChrisVo/cardinals) - La lista de todos los cardenales católicos romanos en formato json
 * [![JavaScript](https://img.shields.io/badge/language-JavaScript-yellow)](#) [romcal](https://github.com/romcal/romcal) - El Calendario Litúrgico utilizado por el Rito Romano (Iglesia Occidental) para Node JS v6 y superior.
 * [![PHP](https://img.shields.io/badge/language-PHP-blue)](#) [roman calendar](https://github.com/jayarathina/Roman-Calendar) - Generador de calendario litúrgico católico romano
 * [![TEX](https://img.shields.io/badge/language-TEX-green)](#) [graduale-romanum-1908](https://github.com/ahinkley/graduale-romanum-1908) - 1908 Edición Vaticana Graduale Romanum reescrito en Gregorio 4

--- a/README.fr.md
+++ b/README.fr.md
@@ -46,6 +46,7 @@ Une liste organisée de superbes projets, bibliothèques et logiciels catholique
 * [![Go](https://img.shields.io/badge/language-Go-cyan)](#) [vulgata](https://github.com/borderstech/vulgata) - La Sainte Bible avec les textes anglais Douay-Reims et Clementina Vulgata latine
 * [![Python](https://img.shields.io/badge/language-Python-blue)](#) [catechism-ccc-json](https://github.com/nossbigg/catechism-ccc-json) - Le Catéchisme de l'Église catholique en JSON.
 * [![Python](https://img.shields.io/badge/language-Python-blue)](#) [pytholic](https://github.com/Medromenax/pytholic) - Forfait python sur le thème catholique
+* [![Python](https://img.shields.io/badge/language-Python-blue)](#) [cardinals](https://github.com/ChrisVo/cardinals) - La liste de tous les cardinaux catholiques romains au format json
 * [![JavaScript](https://img.shields.io/badge/language-JavaScript-yellow)](#) [romcal](https://github.com/romcal/romcal) - Le calendrier liturgique utilisé par le rite romain (église occidentale) pour le nœud JS v6 et supérieur.
 * [![PHP](https://img.shields.io/badge/language-PHP-blue)](#) [roman calendar](https://github.com/jayarathina/Roman-Calendar) - Générateur de calendrier liturgique catholique romain
 * [![TEX](https://img.shields.io/badge/language-TEX-green)](#) [graduale-romanum-1908](https://github.com/ahinkley/graduale-romanum-1908) - Édition du Vatican 1908 Retypeset romain progressif dans Gregorio 4

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A curated list of awesome Catholic projects, libraries and software.
 * [![Go](https://img.shields.io/badge/language-Go-cyan)](#) [vulgata](https://github.com/borderstech/vulgata) - The Holy Bible with both the Douay-Rheims English and Clementina Vulgata Latin texts
 * [![Python](https://img.shields.io/badge/language-Python-blue)](#) [catechism-ccc-json](https://github.com/nossbigg/catechism-ccc-json) - The Catechism of the Catholic Chruch in JSON.
 * [![Python](https://img.shields.io/badge/language-Python-blue)](#) [pytholic](https://github.com/Medromenax/pytholic) - Catholic-themed python package
+* [![Python](https://img.shields.io/badge/language-Python-blue)](#) [cardinals](https://github.com/ChrisVo/cardinals) - The list of all Roman Catholic Cardinals in json format
 * [![JavaScript](https://img.shields.io/badge/language-JavaScript-yellow)](#) [romcal](https://github.com/romcal/romcal) - The Liturgical Calendar used by the Roman Rite (Western Church) for Node JS v6 and above.
 * [![PHP](https://img.shields.io/badge/language-PHP-blue)](#) [roman calendar](https://github.com/jayarathina/Roman-Calendar) - Roman Catholic Liturgical Calendar Generator
 * [![TEX](https://img.shields.io/badge/language-TEX-green)](#) [graduale-romanum-1908](https://github.com/ahinkley/graduale-romanum-1908) - 1908 Vatican Edition Graduale Romanum retypeset in Gregorio 4


### PR DESCRIPTION
I wrote a python script that'll export the entire list of Cardinals in JSON format. Also, on the GitHub repo's release page, there's the JSON file, which will be automatically updated every Friday morning.