### PR TITLE
Fix another minor typo in spasnish

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -75,7 +75,7 @@ Una lista curada de increíbles proyectos católicos, bibliotecas y software.
 * [theocrone](https://github.com/paucazou/theochrone) - Un calendario para el rito tridentino. Demo en http://theochrone.fr
 * [Easter dates](https://easter-dates.gavinr.com/) - Distribución de la Pascua por fecha a lo largo de los años, visualizada.
 * [Confessit](https://github.com/kas-catholic/confessit-web) - Una aplicación web progresiva diseñada para ayudar a los católicos romanos a prepararse para el sacramento de la confesión examinando su conciencia.
-* [Ember Days](https://github.com/saint-isidore-guild/ember-days) - Muestra los días de ascuas de un año determinado.
+* [Ember Days](https://github.com/saint-isidore-guild/ember-days) - Muestra los días de témporas de un año determinado.
 * [Pray the Rosary](https://github.com/marchiartur/pray-the-rosary) - Una aplicación web progresiva diseñada para ayudar a los católicos romanos a rezar el Rosario. Demo en https://prayrosary.netlify.app/
 * [Oficjum](https://github.com/anna-wro/rkk) - Una aplicación web progresiva que proporciona textos litúrgicos diarios para la Liturgia de las Horas en polaco. Demostración en https://oficjum.starokatolicy.eu/
 * [Rosarium](https://github.com/leozamboni/Rosarium) - Aplicación web diseñada para ayudar a los católicos a rezar el Santo Rosario en latín de forma interactiva e inmersiva a través de modelos 3D de iglesias católicas generados mediante fotogrametría. Demostración: https://leozamboni.github.io/Rosarium


### PR DESCRIPTION
Changed 'ascuas,' which literally means 'embers' like in 'hot coal', to 'témporas,' which refers specifically to 'Ember Days' in the religious context.