### PR TITLE
Add catholic ebook libraries and chant tools

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -61,6 +61,8 @@ Una lista curada de increíbles proyectos católicos, bibliotecas y software.
 * [focus-study](https://github.com/rvbcldud/focus-study) - Una colección de estudios bíblicos de FOCUS en formato de folleto.
 * [Baltimore Catechism #2](https://github.com/mattwong97/baltimore-catechism-no-2) - Catecismo de Baltimore n.° 2 en JSON
 * [St. Pius X Catechism](https://github.com/mattwong97/catechism-st-pius-x-frontend) - Catecismo de San Pío X en JSON
+* [liberius.net](http://liberius.net/) - Libros, artículos y documentos católicos.
+* [St. Isidore e-book library](https://isidore.co/calibre/#library_id=CalibreLibrary&panel=book_list) - Colección de e-books católicos.
 
 ## Hardware
 

--- a/README.es.md
+++ b/README.es.md
@@ -107,6 +107,7 @@ Una lista curada de increíbles proyectos católicos, bibliotecas y software.
 * [random-bible-verses](https://github.com/rat9615/random-bible-verses/) - Solicita y muestra pasajes aleatorios de una API de la Biblia.
 * [doctors of the church](https://github.com/masaharumori7/doctors-of-the-church) - Una lista de galería de los 37 Doctores de la Iglesia con descripciones y obras notables.
 * [GregoSearch](https://busca.liturgiacantada.com.br) - GregoSearch es una interfaz de búsqueda moderna y potente para GregoBase, una de las bases de datos más grandes de partituras de canto gregoriano.
+* [JGABC Chant Tools](https://bbloomf.github.io/jgabc/transcriber.html) - Herramientas para cantos gregorianos, incluida una lista de los cantos propios para la misa.
 
 ## Listas-Relacionadas
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -107,6 +107,7 @@ Une liste organisée de superbes projets, bibliothèques et logiciels catholique
 * [random-bible-verses](https://github.com/rat9615/random-bible-verses/) - Demandez et affichez des passages aléatoires à partir d'une API biblique
 * [doctors of the church](https://github.com/masaharumori7/doctors-of-the-church) - Une liste de galerie des 37 docteurs de l'Église avec des descriptions et des œuvres notables
 * [GregoSearch](https://busca.liturgiacantada.com.br) - GregoSearch est une interface de recherche moderne et puissante pour GregoBase, l'une des plus grandes bases de données de partitions de chant grégorien
+* [JGABC Chant Tools](https://bbloomf.github.io/jgabc/transcriber.html) - Outils pour les chants grégoriens, y compris une liste des chants propres pour la messe
 
 ## Listes-Associées
 * [random-bible-verses](https://github.com/rat9615/random-bible-verses/) - Demande et affiche des passages aléatoires à partir d'une API biblique

--- a/README.fr.md
+++ b/README.fr.md
@@ -61,6 +61,8 @@ Une liste organisée de superbes projets, bibliothèques et logiciels catholique
 * [focus-study](https://github.com/rvbcldud/focus-study) - Une collection d'études bibliques FOCUS sous forme de livret.
 * [Baltimore Catechism #2](https://github.com/mattwong97/baltimore-catechism-no-2) - Catéchisme de Baltimore n° 2 en JSON
 * [St. Pius X Catechism](https://github.com/mattwong97/catechism-st-pius-x-frontend) - Catéchisme de saint Pie X en JSON
+* [liberius.net](http://liberius.net/) - Livres, articles et documents catholiques
+* [St. Isidore e-book library](https://isidore.co/calibre/#library_id=CalibreLibrary&panel=book_list) - Collection d’e-books catholiques
 
 ## Matériel
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A curated list of awesome Catholic projects, libraries and software.
 * [random-bible-verses](https://github.com/rat9615/random-bible-verses/) - Requests and displays random passages from a Bible api
 * [doctors of the church](https://github.com/masaharumori7/doctors-of-the-church) - A gallary list of all 37 Doctors of the Church with descriptions and notable works.
 * [GregoSearch](https://busca.liturgiacantada.com.br) - A modern and powerful search interface for GregoBase, one of the largest databases of Gregorian chant scores.
+* [JGABC Chant Tools](https://bbloomf.github.io/jgabc/transcriber.html) - Tools for gregorian chants, including mass propers.
 
 ## Related-Awesome-Lists
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ A curated list of awesome Catholic projects, libraries and software.
 * [focus-study](https://github.com/rvbcldud/focus-study) - A collection of FOCUS Bible studies in booklet format.
 * [Baltimore Catechism #2](https://github.com/mattwong97/baltimore-catechism-no-2) - Baltimore Catechism No. 2 in JSON
 * [St. Pius X Catechism](https://github.com/mattwong97/catechism-st-pius-x-frontend) - Catechism of St. Pius X frontend
+* [liberius.net](http://liberius.net/) - Catholic books, articles and documents.
+* [St. Isidore e-book library](https://isidore.co/calibre/#library_id=CalibreLibrary&panel=book_list) - Collection of Catholic e-books.
 
 ## Hardware
 

--- a/README.pl-pl.md
+++ b/README.pl-pl.md
@@ -107,6 +107,7 @@ Wyselekcjonowana lista niesamowitych katolickich projektów, bibliotek i oprogra
 * [random-bible-verses](https://github.com/rat9615/random-bible-verses/) - Żąda i wyświetla losowe fragmenty z API Biblii
 * [doctors of the church](https://github.com/masaharumori7/doctors-of-the-church) - Lista wszystkich 37 Doktorów Kościoła wraz z opisami i najważniejszymi dziełami.
 * [GregoSearch](https://busca.liturgiacantada.com.br) - GregoSearch to nowoczesny i potężny interfejs wyszukiwania dla GregoBase, jednej z największych baz danych partytur chorału gregoriańskiego.
+* [JGABC Chant Tools](https://bbloomf.github.io/jgabc/transcriber.html) - Narzędzia do chorału gregoriańskiego, w tym lista śpiewów własnych Mszy.
 
 ## Powiązane niesamowite listy
 

--- a/README.pl-pl.md
+++ b/README.pl-pl.md
@@ -61,6 +61,8 @@ Wyselekcjonowana lista niesamowitych katolickich projektów, bibliotek i oprogra
 * [focus-study](https://github.com/rvbcldud/focus-study) - Zbiór studiów biblijnych FOCUS w formie broszury.
 * [Baltimore Catechism #2](https://github.com/mattwong97/baltimore-catechism-no-2) - Katechizm Baltimore nr 2 w JSON
 * [St. Pius X Catechism](https://github.com/mattwong97/catechism-st-pius-x-frontend) - Katechizm św. Piusa X w formacie JSON
+* [liberius.net](http://liberius.net/) - Książki, artykuły i dokumenty katolickie.
+* [St. Isidore e-book library](https://isidore.co/calibre/#library_id=CalibreLibrary&panel=book_list) - Kolekcja katolickich e-booków.
 
 ## Sprzęt komputerowy
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -61,6 +61,8 @@ Uma lista de ótimos projetos, bibliotecas e softwares Católicos.
 * [focus-study](https://github.com/rvbcldud/focus-study) - Uma coleção de estudos bíblicos FOCUS em formato de livreto.
 * [Baltimore Catechism #2](https://github.com/mattwong97/baltimore-catechism-no-2) - Catecismo de Baltimore nº 2 em JSON
 * [St. Pius X Catechism](https://github.com/mattwong97/catechism-st-pius-x-frontend) - frontend do Catecismo de São Pio X
+* [liberius.net](http://liberius.net/) - Livros, artigos e documentos católicos.
+* [St. Isidore e-book library](https://isidore.co/calibre/#library_id=CalibreLibrary&panel=book_list) - Coletânea de e-books católicos.
 
 ## Hardware
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -107,6 +107,7 @@ Uma lista de ótimos projetos, bibliotecas e softwares Católicos.
 * [random-bible-verses](https://github.com/rat9615/random-bible-verses/) - Solicita e exibe passagens aleatórias de uma API da Bíblia
 * [doctors of the church](https://github.com/masaharumori7/doctors-of-the-church) - Uma lista de galeria de todos os 37 Doutores da Igreja com descrições e obras notáveis.
 * [GregoSearch](https://busca.liturgiacantada.com.br) - GregoSearch é uma interface de busca moderna e poderosa para GregoBase, um dos maiores bancos de dados de partituras de canto gregoriano.
+* [JGABC Chant Tools](https://bbloomf.github.io/jgabc/transcriber.html) - Ferramentas para cantos gregorianos, incluindo lista de cantos próprios para missas.
 
 ## Outras listas relacionadas
 


### PR DESCRIPTION
- adds liberius.net (http://liberius.net)
- adds isidore.co (https://isidore.co/calibre/#library_id=CalibreLibrary&panel=book_list)
- adds jgabc chant tools (https://bbloomf.github.io/jgabc/transcriber.html)